### PR TITLE
Fixed link to Ecrire

### DIFF
--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,5 +1,5 @@
 <header id="blogHeader">
-  <p>Welcome to <a href="https://github.com">Ecrire</a>.</p>
+  <p>Welcome to <a href="http://github.com/pothibo/ecrire">Ecrire</a>.</p>
   <p>This is the page your user will see when they reach your blog.</p>
 
   <p>This page can be customized by editing <code class="language-bash">app/views/posts/index.html</code></p>


### PR DESCRIPTION
Put in a link to the repo instead of just Github.  Just a documentation fix, but I just got it running.  :-)
