### PR TITLE
removed shared directory call from post.js in default theme

### DIFF
--- a/themes/default/assets/javascripts/post.js
+++ b/themes/default/assets/javascripts/post.js
@@ -1,2 +1,1 @@
-//= require_tree ./shared
 //= require_tree ./post


### PR DESCRIPTION
This directory call was causing `RAILS_ENV=production bundle exec rake assets:precompile` to fail with the following message.  Since there was no such directory, I removed the call.

```
rake aborted!
require_tree argument must be a directory
  (in /home/joey/apps/ecrire/themes/default/assets/javascripts/post.js:1)
```
