### PR TITLE
Sprocket creates the file if it doesn't exist.

### DIFF
--- a/lib/ecrire/tasks/assets.rake
+++ b/lib/ecrire/tasks/assets.rake
@@ -8,7 +8,7 @@ module Sprockets
   module Rails
     class Task < Rake::SprocketsTask
       def output
-        File.join(Ecrire::Railtie.paths['public'].existent.first, app.config.assets.prefix)
+        File.join(Ecrire::Railtie.paths['public'].expanded.first, app.config.assets.prefix)
       end
     end
   end


### PR DESCRIPTION
That's why there's no need to check if it exists using Path#existent
method.