### PR TITLE
Got sick of using named routes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@
 
 # Ignore all logfiles and tempfiles.
 log
-/tmp
+tmp
 
 .DS_Store
 Gemfile.lock

--- a/lib/ecrire/app/controllers/admin/posts_controller.rb
+++ b/lib/ecrire/app/controllers/admin/posts_controller.rb
@@ -22,7 +22,7 @@ module Admin
         render 'new' and return
       end
 
-      redirect_to edit_admin_post_path(@post)
+      redirect_to url('/admin/posts/:post.id/edit', post: @post)
     end
 
     def destroy
@@ -47,7 +47,7 @@ module Admin
           when 'publish'
             @post.publish!
             flash[:notice] = t(".successful", title: @post.title)
-            redirect_to theme.post_path(@post.year, @post.month, @post) and return
+            redirect_to url(Ecrire::Theme::Engine.post_path, post: @post) and return
           when 'unpublish'
             @post.unpublish!
           end

--- a/lib/ecrire/app/controllers/application_controller.rb
+++ b/lib/ecrire/app/controllers/application_controller.rb
@@ -3,7 +3,7 @@ class ApplicationController < ::ActionController::Base
   protect_from_forgery with: :exception
   helper_method :current_user, :signed_in?
 
-  helper_method :warden, :post_path
+  helper_method :warden, :post_path, :url
 
   def current_user
     warden.user
@@ -12,6 +12,25 @@ class ApplicationController < ::ActionController::Base
   def signed_in?
     !warden.user.nil?
   end
+
+  def url(path, options = {})
+    records = options.with_indifferent_access
+    regex = /(:([a-z]+)\.([a-z]+))/i
+    path.gsub! regex do |match|
+      records[$2].send($3)
+    end
+
+    if options.delete(:full_path)
+      options[:path] = path
+      options[:host] ||= request.host
+      options[:protocol] ||= request.protocol
+      options[:port] ||= request.port
+      ActionDispatch::Http::URL.full_url_for(options)
+    else
+      path
+    end
+  end
+
 
   protected
 

--- a/lib/ecrire/app/models/post.rb
+++ b/lib/ecrire/app/models/post.rb
@@ -70,14 +70,6 @@ class Post < ActiveRecord::Base
     published_at.nil?
   end
 
-  def to_param
-    if self.instance_of?(Admin::Post)
-      id.to_s
-    else
-      slug
-    end
-  end
-
   def content
     (self.compiled_content || super || '').html_safe
   end

--- a/lib/ecrire/theme/engine.rb
+++ b/lib/ecrire/theme/engine.rb
@@ -1,6 +1,7 @@
 module Ecrire
   module Theme
     class Engine < Rails::Engine
+      attr_accessor :post_path
 
       initializer 'ecrire.logs', before: :initialize_logger do |app|
         unless Rails.env.test?

--- a/lib/ecrire/theme/template/routes.rb
+++ b/lib/ecrire/theme/template/routes.rb
@@ -1,3 +1,5 @@
+Ecrire::Theme::Engine.post_path = '/:post.year/:post.month/:post.slug/'
+
 Ecrire::Theme::Engine.routes.draw do
   root 'posts#index'
   

--- a/test/editor/controllers/posts_controller_test.rb
+++ b/test/editor/controllers/posts_controller_test.rb
@@ -13,7 +13,7 @@ class PostsControllerTest < TestController
   test 'creating a new post should redirect to the editor' do
     log_in!
     post :create, post: {title: 'A new post'}
-    assert_redirected_to edit_admin_post_path(assigns(:post))
+    assert_redirected_to @controller.url('/admin/posts/:post.id/edit', post: assigns(:post))
   end
 
   test 'a new post with an existing title should render errors' do
@@ -27,6 +27,6 @@ class PostsControllerTest < TestController
   test "publishing a post redirect the user to the post's URL" do
     log_in!
     put :update, id: Post.status(:draft).first.id, button: :publish
-    assert_redirected_to Ecrire::Theme::Engine.routes.url_helpers.post_path(assigns(:post).year, assigns(:post).month, assigns(:post))
+    assert_redirected_to @controller.url(Ecrire::Theme::Engine.post_path, post: assigns(:post))
   end
 end

--- a/test/editor/theme/routes.rb
+++ b/test/editor/theme/routes.rb
@@ -1,5 +1,9 @@
+Ecrire::Theme::Engine.post_path = '/:post.year/:post.month/:post.slug/'
+
 Ecrire::Theme::Engine.routes.draw do
+
   get '/:year/:month/:id', controller: :posts, action: :show, constraints: { year: /\d+/, month: /\d+/ }, as: "post"
+
   get '/feed', controller: :posts, action: :index, defaults: { format: :rss }
 
   resources :posts, only: [:index]

--- a/test/fixtures/titles.yml
+++ b/test/fixtures/titles.yml
@@ -1,11 +1,14 @@
 published_history:
   name: "An old title"
+  slug: 'an-old-title'
   post: published
 
 published_current:
   name: "Current Title"
+  slug: 'current-title'
   post: published
 
 draft:
   name: "A draft"
+  slug: 'a-draft'
   post: draft


### PR DESCRIPTION
Named routes module is a leaky abstraction. First, routes are split when
the engines are isolated, which isn't always obvious. Then, I always
have to type ````rake routes``` to remember what named routes I should
use.

Third, and probably the most important, is that keys cannot be map
easily to an object which I think is pretty dumb since URLs are *built*
with models. to_param returning a string instead of a hash was just the
icing on the cake.

So, instead of trying to be extra clever about everything, I decided to
introduce a ```url(string, options ={})``` method where you pass a url
structure as a first parameter and a hash with the objects you want to
map into the URL.

Here's an example

~~~ruby
 # Before:
post_path(@post.year, @post.month, @post.slug)
 # After:
url('/:post.year/:post.month/:post.slug/', post: @post)
~~~

Nested resources now can be as complex as you want. Here's an example

~~~ruby
 # This method could return all post published in a year with the given
 # tag.
 # The named routes would require you to do either complex
 # routing/parsing or would need to use GET params.
url('/tags/:tag.id/posts/:post.year', tag: @tag, post: @post)
~~~

This, I believe, is much easier to maintain and understand.