### PR TITLE
[ci-skip] The default theme looks for ecrire in a local development path. Fix that

### DIFF
--- a/lib/ecrire/theme/template/Gemfile
+++ b/lib/ecrire/theme/template/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'ecrire',               path: '~/Develop/ecrire'
+gem 'ecrire',               git: 'https://github.com/pothibo/ecrire'
 
 group :required do
   gem 'rails',             '~> 4.2'


### PR DESCRIPTION
by using git@master which should fix #130