### PR TITLE
Inline code can be represented in a list.

### DIFF
--- a/lib/ecrire/app/assets/javascripts/admin/editor/content.coffee
+++ b/lib/ecrire/app/assets/javascripts/admin/editor/content.coffee
@@ -366,8 +366,8 @@ class Parsers
 
   sort: =>
     [
-      @store.code
       @store.lists
+      @store.code
       @store.image
       @store.headers
       @store.link


### PR DESCRIPTION
This should fix #149. The only change needed was to reorder the parsing
of the document.