### PR TITLE
Don't compile assets in production

### DIFF
--- a/lib/ecrire/config/environment/production.rb
+++ b/lib/ecrire/config/environment/production.rb
@@ -1,7 +1,8 @@
 Ecrire::Application.configure do
   config.assets.js_compressor = :uglifier
   config.assets.debug = false
-  config.assets.compile = true
+  config.assets.compress = true
+  config.assets.compile = false
   config.assets.digest = true
   config.assets.version = '1.0'
 


### PR DESCRIPTION
The reason why Ecrire has a slow boot in production is due to the fact that it compiles all assets. Since all assets are served via nginx/apache/etc, it's redundant and useless to do that.